### PR TITLE
No longer depends on null only being for lists

### DIFF
--- a/Data/Boolean/SatSolver.hs
+++ b/Data/Boolean/SatSolver.hs
@@ -103,7 +103,7 @@ solve solver
 -- and only if that fails.
 -- 
 isSolvable :: SatSolver -> Bool
-isSolvable = not . null . solve
+isSolvable solver = case solve solver of [] -> False; _ -> True
 
 
 -- private helper functions


### PR DESCRIPTION
On the current GHC library, null now takes a Foldable rather than a list, which was causing the changed line of code to have a type class ambiguity. I got rid of the dependence on null.
