### PR TITLE
Makes package build on GHC 8.

### DIFF
--- a/Data/Boolean/SatSolver.hs
+++ b/Data/Boolean/SatSolver.hs
@@ -103,7 +103,7 @@ solve solver
 -- and only if that fails.
 -- 
 isSolvable :: SatSolver -> Bool
-isSolvable = not . null . solve
+isSolvable = not . (null :: [SatSolver] -> Bool) . solve
 
 
 -- private helper functions


### PR DESCRIPTION
incremental-sat-solver currently does not build on GHC 8. The new GHC base makes the `null` function polymorphic over Foldables, rather than limiting it to lists. This change was causing an ambiguity in a case where the particular Foldable wasn’t determined by the argument. I added a type annotation on `null` which instantiates it correctly.